### PR TITLE
Add pos_proportions

### DIFF
--- a/textdescriptives/__init__.py
+++ b/textdescriptives/__init__.py
@@ -1,5 +1,5 @@
 from .load_components import TextDescriptives
-from .components import DescriptiveStatistics, Readability, DependencyDistance
+from .components import DescriptiveStatistics, Readability, DependencyDistance, POSStatistics
 from .dataframe_extract import (
     extract_df,
     extract_dict,

--- a/textdescriptives/components/__init__.py
+++ b/textdescriptives/components/__init__.py
@@ -1,3 +1,4 @@
 from .readability import Readability
 from .dependency_distance import DependencyDistance
 from .descriptive_stats import DescriptiveStatistics
+from .pos_stats import POSStatistics

--- a/textdescriptives/components/descriptive_stats.py
+++ b/textdescriptives/components/descriptive_stats.py
@@ -1,7 +1,7 @@
 """Calculation of descriptive statistics."""
 from spacy.tokens import Doc, Span
 from spacy.language import Language
-from typing import Union
+from typing import Union, Counter
 import numpy as np
 
 from .utils import filtered_tokens, n_tokens, n_syllables, n_sentences
@@ -33,6 +33,7 @@ class DescriptiveStatistics:
             "sentence_length",
             "syllables",
             "counts",
+            "pos_proportions"
         ]
         ext_funs = [
             n_sentences,
@@ -42,6 +43,7 @@ class DescriptiveStatistics:
             self.sentence_length,
             self.syllables,
             self.counts,
+            self.pos_proportions,
         ]
         for ext, fun in zip(extensions, ext_funs):
             if ext not in ["_n_sentences", "sentence_length", "syllables"]:
@@ -124,3 +126,20 @@ class DescriptiveStatistics:
         if isinstance(doc, Doc):
             out["n_sentences"] = doc._._n_sentences
         return out
+
+    def pos_proportions(self, doc: Doc) -> dict:
+        """
+            Returns:
+                Dict with proportions of part-of-speech tag in doc.
+        """
+        pos_counts = Counter()
+    
+        for token in doc:
+            pos_counts[token.tag_] += 1
+
+        pos_proportions = {}
+
+        for tag in pos_counts:
+            pos_proportions[tag] = pos_counts[tag] / sum(pos_counts.values())
+
+        return pos_proportions

--- a/textdescriptives/components/descriptive_stats.py
+++ b/textdescriptives/components/descriptive_stats.py
@@ -134,12 +134,9 @@ class DescriptiveStatistics:
         """
         pos_counts = Counter()
     
-        for token in doc:
-            pos_counts[token.tag_] += 1
+pos_counts.update([token.tag_ for token in doc])
 
-        pos_proportions = {}
+    pos_proportions = {tag : pos_counts[tag] / sum(pos_counts.values()) for tag in pos_counts}
 
-        for tag in pos_counts:
-            pos_proportions[tag] = pos_counts[tag] / sum(pos_counts.values())
 
         return pos_proportions

--- a/textdescriptives/components/descriptive_stats.py
+++ b/textdescriptives/components/descriptive_stats.py
@@ -97,6 +97,13 @@ class DescriptiveStatistics:
         }
 
     def counts(self, doc: Union[Doc, Span], ignore_whitespace: bool = True):
+        """Returns:
+             Dict with keys:
+                n_tokens,
+                n_unique_tokens,
+                proportion_unique_tokens,
+                n_characters
+        """
         n_tokens = doc._._n_tokens
         n_types = len(set([tok.lower_ for tok in doc._._filtered_tokens]))
         if ignore_whitespace:

--- a/textdescriptives/components/descriptive_stats.py
+++ b/textdescriptives/components/descriptive_stats.py
@@ -1,7 +1,7 @@
 """Calculation of descriptive statistics."""
 from spacy.tokens import Doc, Span
 from spacy.language import Language
-from typing import Union, Counter
+from typing import Union
 import numpy as np
 
 from .utils import filtered_tokens, n_tokens, n_syllables, n_sentences
@@ -33,7 +33,6 @@ class DescriptiveStatistics:
             "sentence_length",
             "syllables",
             "counts",
-            "pos_proportions"
         ]
         ext_funs = [
             n_sentences,
@@ -43,7 +42,6 @@ class DescriptiveStatistics:
             self.sentence_length,
             self.syllables,
             self.counts,
-            self.pos_proportions,
         ]
         for ext, fun in zip(extensions, ext_funs):
             if ext not in ["_n_sentences", "sentence_length", "syllables"]:
@@ -126,17 +124,3 @@ class DescriptiveStatistics:
         if isinstance(doc, Doc):
             out["n_sentences"] = doc._._n_sentences
         return out
-
-    def pos_proportions(self, doc: Doc) -> dict:
-        """
-            Returns:
-                Dict with proportions of part-of-speech tag in doc.
-        """
-        pos_counts = Counter()
-    
-pos_counts.update([token.tag_ for token in doc])
-
-    pos_proportions = {tag : pos_counts[tag] / sum(pos_counts.values()) for tag in pos_counts}
-
-
-        return pos_proportions

--- a/textdescriptives/components/pos_stats.py
+++ b/textdescriptives/components/pos_stats.py
@@ -1,0 +1,62 @@
+"""Calculation of statistics that require a pos-tagger in the pipeline"""
+
+from spacy.tokens import Doc, Span
+from spacy.language import Language
+from typing import Counter
+
+from .utils import filtered_tokens
+
+@Language.factory("pos_stats")
+def create_pos_stats_component(nlp: Language, name: str):
+    """Allows PosStats to be added to a spaCy pipe using nlp.add_pipe("pos_stats").
+    If the pipe does not contain a tagger, is is silently added."""
+
+    tagger = set(["tagger"])
+    if not tagger.intersection(set(nlp.pipe_names)):
+        nlp.add_pipe("tagger")  # add a tagger if not one in pipe
+    return POSStatistics(nlp)
+
+class POSStatistics:
+    """spaCy v.3.0 component that adds attributes for POS statistics to `Doc` and `Span` objects.
+    """
+
+    def __init__(self, nlp: Language):
+        """Initialise components"""
+
+        extensions = [
+            "pos_proportions",
+        ]
+        ext_funs = [
+            self.pos_proportions,
+        ]
+        
+        # Unsure about how much of the below tooling code to keep; depends on whether we'll extend pos_stats in the future
+        for ext, fun in zip(extensions, ext_funs): 
+            if ext not in ["_n_sentences", "sentence_length", "syllables"]:
+                if not Span.has_extension(ext):
+                    Span.set_extension(ext, getter=fun)
+            if not Doc.has_extension(ext):
+                Doc.set_extension(ext, getter=fun)
+
+        if not Doc.has_extension("_filtered_tokens"):
+            Doc.set_extension("_filtered_tokens", default=[])
+        if not Span.has_extension("_filtered_tokens"):
+            Span.set_extension("_filtered_tokens", getter=filtered_tokens)
+
+    def __call__(self, doc):
+        """Run the pipeline component"""
+        doc._._filtered_tokens = filtered_tokens(doc)
+        return doc
+
+    def pos_proportions(self, doc: Doc) -> dict:
+        """
+            Returns:
+                Dict with proportions of part-of-speech tag in doc.
+        """
+        pos_counts = Counter()
+    
+        pos_counts.update([token.tag_ for token in doc])
+
+        pos_proportions = {tag : pos_counts[tag] / sum(pos_counts.values()) for tag in pos_counts}
+
+        return pos_proportions

--- a/textdescriptives/dataframe_extract.py
+++ b/textdescriptives/dataframe_extract.py
@@ -58,6 +58,8 @@ class Extractor:
                 extraction.append(self.__readability(doc))
             if doc.has_extension("dependency_distance"):
                 extraction.append(self.__dependency_distance(doc))
+            if doc.has_extension("pos_proportions"):
+                extraction.append(self.__pos_proportions(doc))
         else:
             if "descriptive_stats" in metrics:
                 extraction.append(self.__descriptive_stats(doc))
@@ -77,6 +79,7 @@ class Extractor:
             **doc._.sentence_length,
             **doc._.syllables,
             **doc._.counts,
+            **doc._.pos_proportions,
         }
         if self.as_dict:
             return descriptive_stats

--- a/textdescriptives/tests/test_descriptive_stats.py
+++ b/textdescriptives/tests/test_descriptive_stats.py
@@ -19,7 +19,6 @@ def test_descriptive_stats(nlp):
     assert doc._.sentence_length
     assert doc._.syllables
     assert doc._.counts
-    assert doc._.pos_proportions
     assert doc[0:3]._.token_length
     assert doc[0:3]._.counts
 
@@ -75,13 +74,6 @@ def test_counts(nlp):
     assert doc[0:6]._.counts["proportion_unique_tokens"] == 1.0
     assert doc[0:6]._.counts["n_characters"] == 23
 
-def test_pos_proportions(nlp):
-    doc = nlp(
-        "Here is the first sentence. It was pretty short. Let's make another one that's slightly longer and more complex."
-    )
-
-    assert doc._.pos_proportions == {'RB': 0.125, 'VBZ': 0.08333333333333333, 'DT': 0.08333333333333333, 'JJ': 0.125, 'NN': 0.08333333333333333, '.': 0.125, 'PRP': 0.08333333333333333, 'VBD': 0.041666666666666664, 'VB': 0.08333333333333333, 'WDT': 0.041666666666666664, 'JJR': 0.041666666666666664, 'CC': 0.041666666666666664, 'RBR': 0.041666666666666664}
-
 @pytest.mark.parametrize("text", ["", "#"])
 def test_descriptive_edge(text, nlp):
     doc = nlp(text)
@@ -89,4 +81,3 @@ def test_descriptive_edge(text, nlp):
     assert doc._.sentence_length
     assert doc._.syllables
     assert doc._.counts
-    assert doc._.pos_proportions

--- a/textdescriptives/tests/test_descriptive_stats.py
+++ b/textdescriptives/tests/test_descriptive_stats.py
@@ -19,6 +19,7 @@ def test_descriptive_stats(nlp):
     assert doc._.sentence_length
     assert doc._.syllables
     assert doc._.counts
+    assert doc._.pos_proportions
     assert doc[0:3]._.token_length
     assert doc[0:3]._.counts
 
@@ -74,6 +75,12 @@ def test_counts(nlp):
     assert doc[0:6]._.counts["proportion_unique_tokens"] == 1.0
     assert doc[0:6]._.counts["n_characters"] == 23
 
+def test_pos_proportions(nlp):
+    doc = nlp(
+        "Here is the first sentence. It was pretty short. Let's make another one that's slightly longer and more complex."
+    )
+
+    assert doc._.pos_proportions == {'RB': 0.125, 'VBZ': 0.08333333333333333, 'DT': 0.08333333333333333, 'JJ': 0.125, 'NN': 0.08333333333333333, '.': 0.125, 'PRP': 0.08333333333333333, 'VBD': 0.041666666666666664, 'VB': 0.08333333333333333, 'WDT': 0.041666666666666664, 'JJR': 0.041666666666666664, 'CC': 0.041666666666666664, 'RBR': 0.041666666666666664}
 
 @pytest.mark.parametrize("text", ["", "#"])
 def test_descriptive_edge(text, nlp):
@@ -82,3 +89,4 @@ def test_descriptive_edge(text, nlp):
     assert doc._.sentence_length
     assert doc._.syllables
     assert doc._.counts
+    assert doc._.pos_proportions

--- a/textdescriptives/tests/test_pos_stats.py
+++ b/textdescriptives/tests/test_pos_stats.py
@@ -1,0 +1,22 @@
+import spacy
+from spacy.lang.en import English
+import pytest
+from textdescriptives.components import POSStatistics
+
+@pytest.fixture(scope="function")
+
+def nlp():
+    nlp = spacy.load("en_core_web_sm", disable=('ner', 'textcat'))
+    nlp.add_pipe("pos_stats")
+
+    return nlp
+
+def test_pos_integrations(nlp):
+    assert "pos_stats" == nlp.pipe_names[-1]
+
+def test_pos_proportions(nlp):
+    doc = nlp(
+        "Here is the first sentence. It was pretty short. Let's make another one that's slightly longer and more complex."
+    )
+
+    assert doc._.pos_proportions == {'RB': 0.125, 'VBZ': 0.08333333333333333, 'DT': 0.08333333333333333, 'JJ': 0.125, 'NN': 0.08333333333333333, '.': 0.125, 'PRP': 0.08333333333333333, 'VBD': 0.041666666666666664, 'VB': 0.08333333333333333, 'WDT': 0.041666666666666664, 'JJR': 0.041666666666666664, 'CC': 0.041666666666666664, 'RBR': 0.041666666666666664}


### PR DESCRIPTION
Here goes!

The function runs fine separate from the package:

```python

import spacy
from typing import Counter
from spacy.tokens import Doc, Span

# Load English tokenizer, tagger, parser and NER
nlp = spacy.load("en_core_web_sm")

# Process whole documents
text = ("Here is the first sentence. It was pretty short, yes. Let's make another one that's slightly longer and more complex.")

doc = nlp(text)

def pos_proportions(doc: Doc) -> dict:
        """
            Returns:
                Dict with proportions of part-of-speech tag in doc.
        """
        pos_counts = Counter()
    
        for token in doc:
            pos_counts[token.tag_] += 1

        pos_proportions = {}

        for tag in pos_counts:
            pos_proportions[tag] = pos_counts[tag] / sum(pos_counts.values())

        return pos_proportions

print(pos_proportions(doc))

```

However, the test fails with:

```
textdescriptives/tests/test_descriptive_stats.py F                       [100%]

=================================== FAILURES ===================================
_____________________________ test_pos_proportions _____________________________

nlp = <spacy.lang.en.English object at 0x7ffc82162550>

    def test_pos_proportions(nlp):
        doc = nlp(
            "Here is the first sentence. It was pretty short. Let's make another one that's slightly longer and more complex."
        )
    
>       assert doc._.pos_proportions == {'RB': 0.125, 'VBZ': 0.08333333333333333, 'DT': 0.08333333333333333, 'JJ': 0.125, 'NN': 0.08333333333333333, '.': 0.125, 'PRP': 0.08333333333333333, 'VBD': 0.041666666666666664, 'VB': 0.08333333333333333, 'WDT': 0.041666666666666664, 'JJR': 0.041666666666666664, 'CC': 0.041666666666666664, 'RBR': 0.041666666666666664}
E       AssertionError: assert {'': 1.0} == {'.': 0.125, ...': 0.125, ...}
E         Left contains 1 more item:
E         {'': 1.0}
E         Right contains 13 more items:
E         {'.': 0.125,
E          'CC': 0.041666666666666664,
E          'DT': 0.08333333333333333,
E          'JJ': 0.125,...
```

I wager that's because I've not implemented the function correctly in the package somewhere, and would love a hand with that :-)