### PR TITLE
HLasse/Make-`quality`-work-with-`n_process`->-1

### DIFF
--- a/textdescriptives/components/coherence.py
+++ b/textdescriptives/components/coherence.py
@@ -5,9 +5,9 @@ from spacy.language import Language
 from spacy.tokens import Doc
 
 
-@Language.factory("textdescriptives.coherence")
+@Language.factory("textdescriptives/coherence")
 def create_coherence_component(nlp: Language, name: str):
-    """Allows Coherence to be added to a spaCy pipe using nlp.add_pipe("textdescriptives.coherence").
+    """Allows Coherence to be added to a spaCy pipe using nlp.add_pipe("textdescriptives/coherence").
     If the pipe does not contain a parser or sentencizer, the sentencizer component is silently added."""
     return Coherence(nlp)
 

--- a/textdescriptives/components/quality.py
+++ b/textdescriptives/components/quality.py
@@ -469,12 +469,12 @@ class Quality:
         """Set required extensions."""
 
         for ext_name, span_getter in self.extensions.items():
-            doc_getter = span_getter_to_doc_getter(span_getter)
+            # doc_getter = span_getter_to_doc_getter(span_getter)
 
             if not Span.has_extension(ext_name) or self.force is True:
                 Span.set_extension(ext_name, getter=span_getter, force=True)
             if not Doc.has_extension(ext_name) or self.force is True:
-                Doc.set_extension(ext_name, getter=doc_getter, force=True)
+                Doc.set_extension(ext_name, getter=span_getter, force=True)
 
 
 @Language.factory(

--- a/textdescriptives/tests/test_coherence.py
+++ b/textdescriptives/tests/test_coherence.py
@@ -8,12 +8,12 @@ from textdescriptives.components import Coherence
 @pytest.fixture(scope="function")
 def nlp():
     nlp = spacy.load("en_core_web_sm")
-    nlp.add_pipe("textdescriptives.coherence")
+    nlp.add_pipe("textdescriptives/coherence")
     return nlp
 
 
 def test_coherence_integration(nlp):
-    assert "textdescriptives.coherence" == nlp.pipe_names[-1]
+    assert "textdescriptives/coherence" == nlp.pipe_names[-1]
 
 
 def test_coherence(nlp):

--- a/textdescriptives/tests/test_quality.py
+++ b/textdescriptives/tests/test_quality.py
@@ -260,9 +260,8 @@ def test_passed_quality_check(text: str, passed: bool, nlp: spacy.Language):
 
 
 def test_quality_multi_process(nlp):
-    texts = [oliver_twist, secret_garden, flatland]
-    texts = [ftfy.fix_text(text) for text in texts]
+    texts = ["A couple of texts here, yeah yeah yeah.", "This is a second text, no repetition what so ever."]
 
-    docs = nlp.pipe(texts, n_process=3)
+    docs = nlp.pipe(texts, n_process=2)
     for doc in docs:
         assert doc._.quality


### PR DESCRIPTION
`span_to_doc_getter` is not serializable (as it saves the span) -- but -- is it really necesarry? From what I can gather, all the span getters should work just fine on docs too. Anything I'm missing?