### PR TITLE
build: remove test coverage badge

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,16 +78,4 @@ jobs:
           echo "Coverage Report - ${{ steps.coverage-comment.outputs.coverage }}"
           echo "Coverage Color - ${{ steps.coverage-comment.outputs.color }}"
 
-      # and if it is a push to main then create the badge
-      - name: Create the Badge
-        if: ${{ github.event_name == 'push' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9' }}
-        uses: schneegans/dynamic-badges-action@v1.6.0
-        with:
-          auth: ${{ secrets.PYTEST_COVERAGE }}
-          gistID: 24ee79064ca9d49616cbc410da65cee2
-          filename: badge-textdescriptives-pytest-coverage.json
-          label: Coverage
-          message: ${{ steps.coverage-comment.outputs.coverage }}
-          color: ${{ steps.coverage-comment.outputs.color }}
-          namedLogo: python
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 [![spacy](https://img.shields.io/badge/built%20with-spaCy-09a3d5.svg)](https://spacy.io)
 [![github actions pytest](https://github.com/hlasse/textdescriptives/actions/workflows/tests.yml/badge.svg)](https://github.com/hlasse/textdescriptives/actions)
 [![github actions docs](https://github.com/hlasse/textdescriptives/actions/workflows/documentation.yml/badge.svg)](https://hlasse.github.io/TextDescriptives/)
-![github coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/hlasse/24ee79064ca9d49616cbc410da65cee2/raw/badge-textdescriptives-pytest-coverage.json)
 [![arXiv](https://img.shields.io/badge/arXiv-2301.02057-b31b1b.svg)](https://arxiv.org/abs/2301.02057)
 [![status](https://joss.theoj.org/papers/06447337ee61969b5a64de484199df24/status.svg)](https://joss.theoj.org/papers/06447337ee61969b5a64de484199df24)
 


### PR DESCRIPTION
Removes the test coverage workflow and the badge from readme as it tends to bug out (and is not a particularly valid metric)