### PR TITLE
Download-spacy-model-if-not-on-disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ text = "The world is changed. I feel it in the water. I feel it in the earth. I 
 df = td.extract_metrics(text=text, lang="en", metrics=None)
 
 # specify spaCy model and which metrics to extract
-df = td.extract_metrics(text=text, spacy_model="en_core_web_sm", metrics=["readability", "coherence"])
+df = td.extract_metrics(text=text, spacy_model="en_core_web_lg", metrics=["readability", "coherence"])
 ```
 
 

--- a/docs/usingthepackage.rst
+++ b/docs/usingthepackage.rst
@@ -17,7 +17,7 @@ Specify which metrics to extract in the :code:`metrics` argument. :code:`None` e
    df = td.extract_metrics(text=text, lang="en", metrics=None)
 
    # specify spaCy model and which metrics to extract
-   df = td.extract_metrics(text=text, spacy_model="en_core_web_sm", metrics=["readability", "coherence"])
+   df = td.extract_metrics(text=text, spacy_model="en_core_web_lg", metrics=["readability", "coherence"])
 
 
 Usage with spaCy

--- a/src/textdescriptives/components/information_theory.py
+++ b/src/textdescriptives/components/information_theory.py
@@ -10,7 +10,7 @@ from spacy.vocab import Vocab
 from wasabi import msg
 
 
-def set_lexeme_prob_table(vocab: Vocab, verbose: bool = True):
+def set_lexeme_prob_table(vocab: Vocab, verbose: bool = False):
     """Ensure that the pipeline has a lexeme probability table."""
     if not vocab.lookups.has_table("lexeme_prob"):
         if verbose:
@@ -88,7 +88,7 @@ class InformationTheory:
     def __init__(self, nlp: Language, name: str, force: bool) -> None:
         self.name = name
         self.set_extensions(force=force)
-        set_lexeme_prob_table(nlp.vocab)
+        set_lexeme_prob_table(nlp.vocab, verbose=False)
 
     @staticmethod
     def dict_getter(doc: Union[Doc, Span]) -> Dict[str, float]:

--- a/src/textdescriptives/components/readability.py
+++ b/src/textdescriptives/components/readability.py
@@ -161,7 +161,7 @@ class Readability:
 @Language.factory(
     "textdescriptives/readability",
     assigns=["doc._.readability"],
-    default_config={"verbose": True},
+    default_config={"verbose": False},
 )
 def create_readability_component(
     nlp: Language,

--- a/src/textdescriptives/components/readability.py
+++ b/src/textdescriptives/components/readability.py
@@ -198,10 +198,11 @@ def create_readability_component(
         >>> doc = nlp("This is a test document.")
         >>> doc._.readability
     """
-    if "textdescriptives/descriptive_stats" not in nlp.pipe_names and verbose:
-        msg.info(  # pylint: disable=logging-not-lazy
-            "'textdescriptives/descriptive_stats' component is required for"
-            + " 'textdescriptives.readability'. Adding to pipe.",
-        )
-        nlp = nlp.add_pipe("textdescriptives/descriptive_stats")
+    if "textdescriptives/descriptive_stats" not in nlp.pipe_names:
+        if verbose:
+            msg.info(  # pylint: disable=logging-not-lazy
+                "'textdescriptives/descriptive_stats' component is required for"
+                + " 'textdescriptives.readability'. Adding to pipe.",
+            )
+        nlp.add_pipe("textdescriptives/descriptive_stats")
     return Readability(nlp)

--- a/src/textdescriptives/utils.py
+++ b/src/textdescriptives/utils.py
@@ -179,7 +179,9 @@ def _create_spacy_pipeline(
     try:
         return spacy.load(spacy_model)
     except OSError:
-        msg.info(f"""The specified spaCy model "{spacy_model}" was not 
-            found on disk. Downloading...""")
+        msg.info(
+            f"""The specified spaCy model "{spacy_model}" was not 
+            found on disk. Downloading..."""
+        )
         spacy.cli.download(spacy_model)
-        return spacy.load(spacy_model)    
+        return spacy.load(spacy_model)

--- a/src/textdescriptives/utils.py
+++ b/src/textdescriptives/utils.py
@@ -176,4 +176,10 @@ def _create_spacy_pipeline(
             )
         msg.info(f"No spacy model provided. Inferring spacy model for {lang}.")
         spacy_model = _download_spacy_model(lang=lang, size=spacy_model_size)
-    return spacy.load(spacy_model)
+    try:
+        return spacy.load(spacy_model)
+    except OSError:
+        msg.info(f"""The specified spaCy model "{spacy_model}" was not 
+            found on disk. Downloading...""")
+        spacy.cli.download(spacy_model)
+        return spacy.load(spacy_model)    

--- a/src/textdescriptives/utils.py
+++ b/src/textdescriptives/utils.py
@@ -181,7 +181,7 @@ def _create_spacy_pipeline(
     except OSError:
         msg.info(
             f"""The specified spaCy model "{spacy_model}" was not 
-            found on disk. Downloading..."""
+            found on disk. Downloading...""",
         )
         spacy.cli.download(spacy_model)
         return spacy.load(spacy_model)


### PR DESCRIPTION
- Automatically downloads the supplied spaCy model in `extract_metric` if not already on disk. 
- Default verbosity lowered a bit. 
- Changed readme example to use lg model instead of small for correct coherence calculation.