### PR TITLE
Replaces all pos_stats with pos_proportions

### DIFF
--- a/docs/posstats.rst
+++ b/docs/posstats.rst
@@ -1,7 +1,7 @@
 Part-of-Speech Proportions
 -----------------------------
 
-The *pos_stats* component adds one attribute to a Doc or Span:
+The *pos_proportions* component adds one attribute to a Doc or Span:
 
 * :code:`Doc._.pos_proportions` 
     * Dict of :code:`{pos_prop_POSTAG: proportion of all tokens tagged with POSTAG}`. Does not create a key if no tokens in the document fit the POSTAG.
@@ -41,4 +41,4 @@ Usage
 Component
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. autofunction:: textdescriptives.components.pos_proportions.create_pos_stats_component
+.. autofunction:: textdescriptives.components.pos_proportions.create_pos_proportions_component

--- a/src/textdescriptives/components/pos_proportions.py
+++ b/src/textdescriptives/components/pos_proportions.py
@@ -55,7 +55,7 @@ class POSProportions:
     assigns=["doc._.pos_proportions", "span._.pos_proportions"],
     default_config={"use_pos": True},
 )
-def create_pos_stats_component(
+def create_pos_proportions_component(
     nlp: Language,
     name: str,
     use_pos: bool,

--- a/src/textdescriptives/extractors.py
+++ b/src/textdescriptives/extractors.py
@@ -39,7 +39,7 @@ def extract_dict(
         docs (Union[Iterable[Doc],  Doc]): An iterable of spaCy Docs or a single Doc
         metrics (Union[list[str], str, None], optional): Which metrics to extract.
                 One or more of ["descriptive_stats", "readability",
-                "dependency_distance", "pos_stats", "information_theory"].
+                "dependency_distance", "pos_proportions", "information_theory"].
                 Defaults to None in which case it will extract metrics for which a
                 pipeline compoenent has been set.
         include_text (bool, optional): Whether to add an entry containing the text.
@@ -95,7 +95,7 @@ def extract_df(
         docs (Union[Iterable[Doc],  Doc]): An iterable of spaCy Docs or a single Doc
         metrics (Union[list[str], str], optional): Which metrics to extract.
                 One or more of ["descriptive_stats", "readability",
-                "dependency_distance", "pos_stats"]. Defaults to None in which
+                "dependency_distance", "pos_proportions"]. Defaults to None in which
                 case it will extract metrics for which a pipeline compoenent has been
                 set.
         include_text (bool, optional): Whether to add a column containing the text.
@@ -125,7 +125,7 @@ def extract_metrics(
             model for the language. Defaults to None.
         metrics (List[str]): Which metrics to extract.
             One or more of ["descriptive_stats", "readability",
-            "dependency_distance", "pos_stats", "coherence", "quality"]. If None,
+            "dependency_distance", "pos_proportions", "coherence", "quality"]. If None,
             will extract all metrics from textdescriptives. Defaults to None.
         spacy_model_size (str, optional): Size of the spacy model to download.
 

--- a/src/textdescriptives/utils.py
+++ b/src/textdescriptives/utils.py
@@ -151,7 +151,7 @@ def _create_spacy_pipeline(
 
     metrics_requiring_spacy_model = {
         "dependency_distance",
-        "pos_stats",
+        "pos_proportions",
         "coherence",
         "pos_proportions",
     }


### PR DESCRIPTION
This simply replaces all `pos_stats` mentions with `pos_proportions` as apparently that's the intended name. E.g. in the documentation of the extractor functions.

Haven't tested it.