### PR TITLE
feat: add proportions of all pos tags

### DIFF
--- a/docs/posstats.rst
+++ b/docs/posstats.rst
@@ -4,11 +4,13 @@ Part-of-Speech Proportions
 The *pos_proportions* component adds one attribute to a Doc or Span:
 
 * :code:`Doc._.pos_proportions` 
-    * Dict of :code:`{pos_prop_POSTAG: proportion of all tokens tagged with POSTAG}`. Does not create a key if no tokens in the document fit the POSTAG.
+    * Dict of :code:`{pos_prop_POSTAG: proportion of all tokens tagged with POSTAG}`. By default creates a key for each possible POS tag. This behaviour can be turned off 
+    by setting :code:`add_all_tags=False` in the component's initialization.
+
 
 * :code:`Span._.pos_proportions`
 * 
-    * Dict of :code:`{pos_prop_POSTAG: proportion of all tokens tagged with POSTAG}`. Does not create a key if no tokens in the document fit the POSTAG.
+    * Dict of :code:`{pos_prop_POSTAG: proportion of all tokens tagged with POSTAG}`. 
 
 
 Usage
@@ -29,12 +31,11 @@ Usage
     td.extract_df(doc)
 
 
-====  =========================  ==============  ===============  ==============  ===============  ================  ===============  ==============  ==============  ================
-  ..  text                         pos_prop_DET    pos_prop_NOUN    pos_prop_AUX    pos_prop_VERB    pos_prop_PUNCT    pos_prop_PRON    pos_prop_ADP    pos_prop_ADV    pos_prop_SCONJ
-====  =========================  ==============  ===============  ==============  ===============  ================  ===============  ==============  ==============  ================
-   0  The world is changed(...)        0.097561         0.121951       0.0731707         0.170732          0.146341         0.195122       0.0731707       0.0731707         0.0487805
-====  =========================  ==============  ===============  ==============  ===============  ================  ===============  ==============  ==============  ================
-
+====  =========================  ==============  ==============  ==============  ==============  ================  ==============  ===============  ===============  ==============  ===============  ===============  ================  ================  ================  ==============  ===============  ============
+  ..  text                         pos_prop_ADJ    pos_prop_ADP    pos_prop_ADV    pos_prop_AUX    pos_prop_CCONJ    pos_prop_DET    pos_prop_INTJ    pos_prop_NOUN    pos_prop_NUM    pos_prop_PART    pos_prop_PRON    pos_prop_PROPN    pos_prop_PUNCT    pos_prop_SCONJ    pos_prop_SYM    pos_prop_VERB    pos_prop_X
+====  =========================  ==============  ==============  ==============  ==============  ================  ==============  ===============  ===============  ==============  ===============  ===============  ================  ================  ================  ==============  ===============  ============
+   0  The world is changed(...)       0.0243902        0.097561       0.0487805       0.0731707                 0        0.097561                0         0.121951               0                0         0.195122                 0          0.146341         0.0243902               0         0.170732             0
+====  =========================  ==============  ==============  ==============  ==============  ================  ==============  ===============  ===============  ==============  ===============  ===============  ================  ================  ================  ==============  ===============  ============
 -----
 
 

--- a/src/textdescriptives/components/pos_proportions.py
+++ b/src/textdescriptives/components/pos_proportions.py
@@ -6,6 +6,8 @@ import numpy as np
 from spacy.language import Language
 from spacy.tokens import Doc, Span
 
+from textdescriptives.components.utils import all_upos_tags
+
 
 class POSProportions:
     """spaCy v.3.0 component that adds attributes for POS statistics to `Doc`
@@ -23,26 +25,7 @@ class POSProportions:
         """
         self.use_pos: bool = use_pos
         self.add_all_tags: bool = add_all_tags
-        self.all_upos_tags = [
-            "ADJ",
-            "ADP",
-            "ADV",
-            "AUX",
-            "CCONJ",
-            "DET",
-            "INTJ",
-            "NOUN",
-            "NUM",
-            "PART",
-            "PRON",
-            "PROPN",
-            "PUNCT",
-            "SCONJ",
-            "SYM",
-            "VERB",
-            "X",
-        ]
-        self.all_model_tags = nlp.meta["labels"]["tagger"]
+        self.model_tags = all_upos_tags if use_pos else nlp.meta["labels"]["tagger"]
 
         if not Doc.has_extension("pos_proportions"):
             Doc.set_extension("pos_proportions", getter=self.pos_proportions)
@@ -59,10 +42,7 @@ class POSProportions:
                 POSTAG.
         """
         if self.add_all_tags:
-            if self.use_pos:
-                pos_counts: Counter = Counter(self.all_upos_tags)  # type: ignore
-            else:
-                pos_counts: Counter = Counter(self.all_model_tags)  # type: ignore
+            pos_counts: Counter = Counter(self.model_tags)  # type: ignore
         else:
             pos_counts: Counter = Counter()  # type: ignore
 
@@ -127,5 +107,4 @@ def create_pos_proportions_component(
             + "a spaCy model which includes a 'tagger' or an 'attribute ruler' "
             + "component.",
         )
-    return POSProportions(nlp, use_pos=use_pos, add_all_tags=add_all_tags)
     return POSProportions(nlp, use_pos=use_pos, add_all_tags=add_all_tags)

--- a/src/textdescriptives/components/pos_proportions.py
+++ b/src/textdescriptives/components/pos_proportions.py
@@ -16,15 +16,31 @@ class POSProportions:
         Args:
             use_pos: If True, uses the simple POS tag. If False, uses the detailed
                 universal POS tag.
-            add_all_tags: If True, returns proportions of all possible POS tags. 
-                If False, only returns proportions for the POS tags present in the 
+            add_all_tags: If True, returns proportions of all possible POS tags.
+                If False, only returns proportions for the POS tags present in the
                 text.
         """
-        self.use_pos = use_pos
-        self.add_all_tags = add_all_tags
-        self.all_upos_tags = ["ADJ", "ADP", "ADV", "AUX", "CCONJ", "DET", "INTJ",
-                              "NOUN", "NUM", "PART", "PRON", "PROPN", "PUNCT",
-                              "SCONJ", "SYM", "VERB", "X"]
+        self.use_pos: bool = use_pos
+        self.add_all_tags: bool = add_all_tags
+        self.all_upos_tags = [
+            "ADJ",
+            "ADP",
+            "ADV",
+            "AUX",
+            "CCONJ",
+            "DET",
+            "INTJ",
+            "NOUN",
+            "NUM",
+            "PART",
+            "PRON",
+            "PROPN",
+            "PUNCT",
+            "SCONJ",
+            "SYM",
+            "VERB",
+            "X",
+        ]
         self.all_model_tags = nlp.meta["labels"]["tagger"]
 
         if not Doc.has_extension("pos_proportions"):
@@ -39,15 +55,15 @@ class POSProportions:
 
         Returns:
             Dict containing {pos_prop_POSTAG: proportion of all tokens tagged with
-                POSTAG. 
+                POSTAG.
         """
         if self.add_all_tags:
             if self.use_pos:
-                pos_counts = Counter(self.all_upos_tags)
+                pos_counts: Counter = Counter(self.all_upos_tags)  # type: ignore
             else:
-                pos_counts = Counter(self.all_model_tags)
+                pos_counts: Counter = Counter(self.all_model_tags)  # type: ignore
         else:
-            pos_counts: Counter = Counter()
+            pos_counts: Counter = Counter()  # type: ignore
 
         if self.use_pos:
             pos_counts.update([token.pos_ for token in text])
@@ -55,7 +71,8 @@ class POSProportions:
             pos_counts.update([token.tag_ for token in text])
         return {
             # subtract 1 from count to account for the instantiation of the counter
-            "pos_prop_" + tag: (count - 1) / len(text) for tag, count in pos_counts.items()
+            f"pos_prop_{tag}": (count - 1) / len(text)
+            for tag, count in pos_counts.items()
         }
 
     def __call__(self, doc):

--- a/src/textdescriptives/components/pos_proportions.py
+++ b/src/textdescriptives/components/pos_proportions.py
@@ -74,7 +74,7 @@ class POSProportions:
         return {
             # subtract 1 from count to account for the instantiation of the counter
             f"pos_prop_{tag}": (count - 1) / len(text) if len_text > 0 else np.nan
-            for tag, count in pos_counts.items() 
+            for tag, count in pos_counts.items()
         }
 
     def __call__(self, doc):

--- a/src/textdescriptives/components/pos_proportions.py
+++ b/src/textdescriptives/components/pos_proportions.py
@@ -2,6 +2,7 @@
 
 from typing import Callable, Counter, Union
 
+import numpy as np
 from spacy.language import Language
 from spacy.tokens import Doc, Span
 
@@ -69,10 +70,11 @@ class POSProportions:
             pos_counts.update([token.pos_ for token in text])
         else:
             pos_counts.update([token.tag_ for token in text])
+        len_text = len(text)
         return {
             # subtract 1 from count to account for the instantiation of the counter
-            f"pos_prop_{tag}": (count - 1) / len(text)
-            for tag, count in pos_counts.items()
+            f"pos_prop_{tag}": (count - 1) / len(text) if len_text > 0 else np.nan
+            for tag, count in pos_counts.items() 
         }
 
     def __call__(self, doc):
@@ -125,4 +127,5 @@ def create_pos_proportions_component(
             + "a spaCy model which includes a 'tagger' or an 'attribute ruler' "
             + "component.",
         )
+    return POSProportions(nlp, use_pos=use_pos, add_all_tags=add_all_tags)
     return POSProportions(nlp, use_pos=use_pos, add_all_tags=add_all_tags)

--- a/src/textdescriptives/components/utils.py
+++ b/src/textdescriptives/components/utils.py
@@ -35,3 +35,24 @@ def n_syllables(doc: Doc):
         return max(1, word_hyphenated.count("-") + 1)
 
     return [count_syl(token) for token in filter_tokens(doc)]
+
+
+all_upos_tags = [
+    "ADJ",
+    "ADP",
+    "ADV",
+    "AUX",
+    "CCONJ",
+    "DET",
+    "INTJ",
+    "NOUN",
+    "NUM",
+    "PART",
+    "PRON",
+    "PROPN",
+    "PUNCT",
+    "SCONJ",
+    "SYM",
+    "VERB",
+    "X",
+]

--- a/tests/test_pos_proportions.py
+++ b/tests/test_pos_proportions.py
@@ -1,6 +1,7 @@
 import pytest
 import spacy
 from spacy.tokens import Doc
+
 import textdescriptives as td  # noqa: F401
 
 
@@ -81,15 +82,23 @@ def test_pos_integrations(nlp):
 def test_pos_proportions_doc(doc):
     assert doc._.pos_proportions == pytest.approx(
         {
-            "pos_prop_ADV": 0.1666,
-            "pos_prop_AUX": 0.125,
-            "pos_prop_DET": 0.083,
             "pos_prop_ADJ": 0.1666,
-            "pos_prop_NOUN": 0.0833,
-            "pos_prop_PUNCT": 0.125,
-            "pos_prop_PRON": 0.125,
-            "pos_prop_VERB": 0.083,
+            "pos_prop_ADP": 0.0,
+            "pos_prop_AUX": 0.125,
+            "pos_prop_ADV": 0.1666,
             "pos_prop_CCONJ": 0.0416,
+            "pos_prop_DET": 0.083,
+            "pos_prop_INTJ": 0.0,
+            "pos_prop_NOUN": 0.0833,
+            "pos_prop_NUM": 0.0,
+            "pos_prop_PART": 0.0,
+            "pos_prop_PRON": 0.125,
+            "pos_prop_PROPN": 0.0,
+            "pos_prop_PUNCT": 0.125,
+            "pos_prop_SCONJ": 0.0,
+            "pos_prop_SYM": 0.0,
+            "pos_prop_VERB": 0.083,
+            "pos_prop_X": 0.0,
         },
         rel=0.05,
     )
@@ -100,15 +109,23 @@ def test_pos_proportions_span(doc):
 
     assert span._.pos_proportions == pytest.approx(
         {
-            "pos_prop_ADV": 0.1666,
-            "pos_prop_AUX": 0.125,
-            "pos_prop_DET": 0.083,
             "pos_prop_ADJ": 0.1666,
-            "pos_prop_NOUN": 0.0833,
-            "pos_prop_PUNCT": 0.125,
-            "pos_prop_PRON": 0.125,
-            "pos_prop_VERB": 0.083,
+            "pos_prop_ADP": 0.0,
+            "pos_prop_AUX": 0.125,
+            "pos_prop_ADV": 0.1666,
             "pos_prop_CCONJ": 0.0416,
+            "pos_prop_DET": 0.083,
+            "pos_prop_INTJ": 0.0,
+            "pos_prop_NOUN": 0.0833,
+            "pos_prop_NUM": 0.0,
+            "pos_prop_PART": 0.0,
+            "pos_prop_PRON": 0.125,
+            "pos_prop_PROPN": 0.0,
+            "pos_prop_PUNCT": 0.125,
+            "pos_prop_SCONJ": 0.0,
+            "pos_prop_SYM": 0.0,
+            "pos_prop_VERB": 0.083,
+            "pos_prop_X": 0.0,
         },
         rel=0.01,
     )


### PR DESCRIPTION
Adds the proportions of all UPOS tags to the output of `pos_proportions` by default. Can be toggled during instantiation. 