### PR TITLE
ci: codespell ignore changelog

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         args: [
             "-w", # Write changes to files
             "--skip",
-            "*.csv,*.bib,tests/books.py,*.ipynb",
+            "*.csv,*.bib,tests/books.py,*.ipynb,CHANGELOG.md",
             # don't code output from notebooks
             "-L",
             "vise", # Ignore the Danish word 'vise'


### PR DESCRIPTION
Typo in commit message caused codespell to fail when pushing to main due to checking CHANGELOG.md for typos. Made codespell skip the changelog