### PR TITLE
Fix docstrings example module import error & Add doctrings missing imports

### DIFF
--- a/src/textdescriptives/components/coherence.py
+++ b/src/textdescriptives/components/coherence.py
@@ -138,6 +138,7 @@ def create_coherence_component(nlp: Language, name: str) -> Callable[[Doc], Doc]
 
     Examples:
         >>> import spacy
+        >>> import textdescriptives as td
         >>> nlp = spacy.load("en_core_web_md")
         >>> nlp.add_pipe("textdescriptives/coherence")
         >>> # apply the pipeline to a text

--- a/src/textdescriptives/components/dependency_distance.py
+++ b/src/textdescriptives/components/dependency_distance.py
@@ -132,6 +132,7 @@ def create_dependency_distance_component(
 
     Example:
         >>> import spacy
+        >>> import textdescriptives as td
         >>> nlp = spacy.load("en_core_web_sm")
         >>> nlp.add_pipe("textdescriptives/dependency_distance")
         >>> # apply the pipeline to a text

--- a/src/textdescriptives/components/descriptive_stats.py
+++ b/src/textdescriptives/components/descriptive_stats.py
@@ -224,6 +224,7 @@ def create_descriptive_stats_component(
 
     Example:
         >>> import spacy
+        >>> import textdescriptives as td
         >>> nlp = spacy.blank("en")
         >>> # add sentencizer
         >>> nlp.add_pipe("sentencizer")

--- a/src/textdescriptives/components/information_theory.py
+++ b/src/textdescriptives/components/information_theory.py
@@ -173,7 +173,8 @@ def create_information_theory_component(nlp: Language, name: str) -> Information
 
     Example:
         >>> import spacy
-        >>> nlp = spacy.blank('en_core_web_lg')
+        >>> import textdescriptives as td
+        >>> nlp = spacy.blank('en')
         >>> nlp.add_pipe('textdescriptives/information_theory')
         >>> doc = nlp('This is a sentence.')
         >>> doc._.information_theory

--- a/src/textdescriptives/components/pos_proportions.py
+++ b/src/textdescriptives/components/pos_proportions.py
@@ -105,6 +105,7 @@ def create_pos_proportions_component(
 
     Example:
         >>> import spacy
+        >>> import textdescriptives as td
         >>> nlp = spacy.load("en_core_web_sm")
         >>> nlp.add_pipe("textdescriptives/pos_proportions")
         >>> # apply the component to a document

--- a/src/textdescriptives/components/quality.py
+++ b/src/textdescriptives/components/quality.py
@@ -652,7 +652,7 @@ def create_quality_component(
     Example:
         >>> import spacy
         >>> from spacy_quality import Quality
-        >>> nlp = spacy.blank(("en_core_web_sm")
+        >>> nlp = spacy.blank("en")
         >>> nlp.add_pipe("quality")
         >>> doc = nlp("This is a test")
         >>> # extract quality metrics


### PR DESCRIPTION
This PR fixed two documentation issues:

1) #338 
2) #339  

